### PR TITLE
feat(backend): 暴露模型超时与 LLM 推理强度配置

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -51,6 +51,10 @@ CHAT_MODEL=gpt-4o
 CHAT_API_PROTOCOL=chat_completions
 # 主聊天模型请求超时（秒）。
 CHAT_TIMEOUT_SECONDS=60
+# 文本 LLM reasoning_effort。none/low/medium/high/xhigh 会传给上游；null 表示不传该字段。
+# 作用于主聊天、life、互动决策、schedule、query rewrite、adaptive chunk、label、VLM；
+# 不作用于 embedding、搜索、rerank。
+LLM_REASONING_EFFORT=null
 
 # ----- 生活时间线小模型（可选，留空则复用上面的 LLM 配置）-----
 # 它只负责维护 AI 自己的日常状态 JSON，不负责最终回复。

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -220,6 +220,7 @@ VISION_API_URL=
 VISION_API_KEY=
 VISION_MODEL=qwen-vl-plus
 VISION_DESCRIBE_PROMPT=请用一两句话客观描述这张图片的内容，不要发挥。
+# 在线 chat/responses 路由等待 VLM 描图的总预算（不改变 VisionClient 默认 60 秒 HTTP 超时）
 VISION_TIMEOUT_SECONDS=15
 # 单张图片最大字节（base64 解码后），默认 8MB
 VISION_MAX_IMAGE_BYTES=8388608

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -49,6 +49,8 @@ CHAT_MODEL=gpt-4o
 # chat_completions：兼容性最好；responses：调用上游 /responses，适配只提供该端点的服务。
 # 只影响主聊天模型；生活状态、决策、rerank 等小模型仍使用 Chat Completions。
 CHAT_API_PROTOCOL=chat_completions
+# 主聊天模型请求超时（秒）。
+CHAT_TIMEOUT_SECONDS=60
 
 # ----- 生活时间线小模型（可选，留空则复用上面的 LLM 配置）-----
 # 它只负责维护 AI 自己的日常状态 JSON，不负责最终回复。
@@ -63,6 +65,8 @@ LIFE_TEMPERATURE=0.35
 # 真实 JSON 输出被截断 → life_state.json 不会写入 current 字段 → 每轮死循环重试。
 # 不确定就跑 backend/scripts/diag_life.py，会显示 reasoning_tokens 实际占用。
 LIFE_MAX_TOKENS=1500
+# 生活状态模型请求超时（秒）。
+LIFE_TIMEOUT_SECONDS=12
 # 最长多久让 life 小模型重新判断一次当前状态。0 = 只按 next_update_at / 用户打断触发。
 LIFE_UPDATE_INTERVAL_MINUTES=60
 # 状态模型可建议”晚一点回复”；这里限制实际延迟上限，避免请求卡太久。
@@ -87,6 +91,7 @@ RESPONSE_POLICY_API_KEY=
 RESPONSE_POLICY_MODEL=
 RESPONSE_POLICY_TEMPERATURE=0.2
 RESPONSE_POLICY_MAX_TOKENS=260
+RESPONSE_POLICY_TIMEOUT_SECONDS=8
 
 # ----- 沉默响应（AI 主动选择不回复时的对外格式）-----
 # 决策层判断本轮不应回复时，后端会跳过主模型调用并返回一个空回复。
@@ -157,6 +162,7 @@ EMBEDDING_API_URL=https://maas-api.cn-huabei-1.xf-yun.com/v2
 EMBEDDING_API_KEY=
 EMBEDDING_MODEL=xop3qwen8bembedding
 EMBEDDING_DIM=4096
+EMBEDDING_TIMEOUT_SECONDS=60
 # 请求格式：
 #   array  = OpenAI 标准（input 是 string 数组，一次多条；默认，DashScope/OpenAI/ollama 都支持）
 #   single = 单条模式（input 是单个 string，一次一条；Gitee AI 等只接受这种）
@@ -210,6 +216,7 @@ VISION_API_URL=
 VISION_API_KEY=
 VISION_MODEL=qwen-vl-plus
 VISION_DESCRIBE_PROMPT=请用一两句话客观描述这张图片的内容，不要发挥。
+VISION_TIMEOUT_SECONDS=15
 # 单张图片最大字节（base64 解码后），默认 8MB
 VISION_MAX_IMAGE_BYTES=8388608
 
@@ -315,6 +322,7 @@ ADAPTIVE_CHUNK_API_KEY=
 ADAPTIVE_CHUNK_MODEL=
 ADAPTIVE_CHUNK_TEMPERATURE=0
 ADAPTIVE_CHUNK_MAX_TOKENS=900
+ADAPTIVE_CHUNK_TIMEOUT_SECONDS=60
 ADAPTIVE_CHUNK_MAX_MESSAGES_PER_CALL=80
 ADAPTIVE_CHUNK_TARGET_CHARS=700
 ADAPTIVE_CHUNK_MAX_CHARS=1400
@@ -364,6 +372,7 @@ QUERY_REWRITE_MODEL=
 QUERY_REWRITE_TEMPERATURE=0
 QUERY_REWRITE_MAX_TOKENS=240
 QUERY_REWRITE_MAX_VARIANTS=3
+QUERY_REWRITE_TIMEOUT_SECONDS=30
 
 # rerank：RRF 召回后，把候选记忆交给 LLM 重排，再取 FINAL_CONTEXT_K 注入 prompt。
 # ⚠️ 实测对 glm-4-flash 这类弱小模型是负优化：单次 15-20s + 区分度不如专用 cross-encoder。
@@ -460,6 +469,7 @@ LABELING_ENABLED=false
 LABEL_API_URL=https://open.bigmodel.cn/api/paas/v4
 LABEL_API_KEY=
 LABEL_MODEL=glm-4-flash
+LABEL_TIMEOUT_SECONDS=30
 # 单次 LLM 调用最多塞几条消息
 LABEL_BATCH_SIZE=8
 # 同时允许多少个打标批次请求在飞。1 = 上一批处理完再下一批。
@@ -488,6 +498,7 @@ SCHEDULE_API_KEY=
 SCHEDULE_MODEL=
 SCHEDULE_TEMPERATURE=0.1
 SCHEDULE_MAX_TOKENS=400
+SCHEDULE_TIMEOUT_SECONDS=60
 # 单轮最多解析的 hint 条数；防止刷屏导致小模型成本失控
 SCHEDULE_MAX_HINTS_PER_TURN=5
 # 整批解析的总超时（秒）；到点未完成 → 返回空列表，不阻塞主回复

--- a/backend/xuwen/chat_api/app.py
+++ b/backend/xuwen/chat_api/app.py
@@ -64,6 +64,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             resolved_settings,
             api_protocol=resolved_settings.chat_api_protocol,
             timeout_seconds=resolved_settings.chat_timeout_seconds,
+            include_reasoning_effort=True,
         )
         # life / response_policy / query_rewrite / rerank 都是 fail-open 设计：
         # 单次失败立刻退快路径（缓存 / 规则层 / 原 query / RRF 顺序），重试无意义只会放大延迟。
@@ -73,6 +74,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             api_url=resolved_settings.resolved_life_api_url,
             api_key=resolved_settings.resolved_life_api_key.get_secret_value(),
             timeout_seconds=resolved_settings.life_timeout_seconds,
+            include_reasoning_effort=True,
             max_retries=1,
         )
         response_policy_llm = LLMClient(
@@ -80,6 +82,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             api_url=resolved_settings.resolved_response_policy_api_url,
             api_key=resolved_settings.resolved_response_policy_api_key.get_secret_value(),
             timeout_seconds=resolved_settings.response_policy_timeout_seconds,
+            include_reasoning_effort=True,
             max_retries=1,
         )
         schedule_extractor_llm = LLMClient(
@@ -87,6 +90,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             api_url=resolved_settings.resolved_schedule_api_url,
             api_key=resolved_settings.resolved_schedule_api_key.get_secret_value(),
             timeout_seconds=resolved_settings.schedule_timeout_seconds,
+            include_reasoning_effort=True,
             max_retries=1,
         )
         extra_llms: list[LLMClient] = []
@@ -97,6 +101,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 api_url=resolved_settings.resolved_query_rewrite_api_url,
                 api_key=resolved_settings.resolved_query_rewrite_api_key.get_secret_value(),
                 timeout_seconds=resolved_settings.query_rewrite_timeout_seconds,
+                include_reasoning_effort=True,
                 max_retries=1,
             )
             extra_llms.append(query_rewrite_llm)

--- a/backend/xuwen/chat_api/app.py
+++ b/backend/xuwen/chat_api/app.py
@@ -63,6 +63,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         llm = LLMClient(
             resolved_settings,
             api_protocol=resolved_settings.chat_api_protocol,
+            timeout_seconds=resolved_settings.chat_timeout_seconds,
         )
         # life / response_policy / query_rewrite / rerank 都是 fail-open 设计：
         # 单次失败立刻退快路径（缓存 / 规则层 / 原 query / RRF 顺序），重试无意义只会放大延迟。
@@ -71,18 +72,21 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             resolved_settings,
             api_url=resolved_settings.resolved_life_api_url,
             api_key=resolved_settings.resolved_life_api_key.get_secret_value(),
+            timeout_seconds=resolved_settings.life_timeout_seconds,
             max_retries=1,
         )
         response_policy_llm = LLMClient(
             resolved_settings,
             api_url=resolved_settings.resolved_response_policy_api_url,
             api_key=resolved_settings.resolved_response_policy_api_key.get_secret_value(),
+            timeout_seconds=resolved_settings.response_policy_timeout_seconds,
             max_retries=1,
         )
         schedule_extractor_llm = LLMClient(
             resolved_settings,
             api_url=resolved_settings.resolved_schedule_api_url,
             api_key=resolved_settings.resolved_schedule_api_key.get_secret_value(),
+            timeout_seconds=resolved_settings.schedule_timeout_seconds,
             max_retries=1,
         )
         extra_llms: list[LLMClient] = []
@@ -92,7 +96,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 resolved_settings,
                 api_url=resolved_settings.resolved_query_rewrite_api_url,
                 api_key=resolved_settings.resolved_query_rewrite_api_key.get_secret_value(),
-                timeout_seconds=resolved_settings.rerank_timeout_seconds,
+                timeout_seconds=resolved_settings.query_rewrite_timeout_seconds,
                 max_retries=1,
             )
             extra_llms.append(query_rewrite_llm)

--- a/backend/xuwen/chat_api/llm_client.py
+++ b/backend/xuwen/chat_api/llm_client.py
@@ -62,6 +62,7 @@ class LLMClient:
         api_url: str | None = None,
         api_key: str | None = None,
         api_protocol: ChatApiProtocol = "chat_completions",
+        include_reasoning_effort: bool = False,
         max_retries: int = 3,
     ) -> None:
         self.settings = settings
@@ -70,6 +71,7 @@ class LLMClient:
             timeout=httpx.Timeout(timeout_seconds, connect=10.0),
         )
         self._api_protocol = api_protocol
+        self._include_reasoning_effort = include_reasoning_effort
         self._url = _resolve_llm_endpoint(
             api_url or str(settings.openai_base_url),
             api_protocol,
@@ -208,6 +210,11 @@ class LLMClient:
             payload["messages"] = messages
         if params is None:
             params = GenerationParams()
+        if (
+            self._include_reasoning_effort
+            and self.settings.llm_reasoning_effort != "null"
+        ):
+            payload["reasoning_effort"] = self.settings.llm_reasoning_effort
         if params.temperature is not None:
             payload["temperature"] = params.temperature
         if params.top_p is not None:

--- a/backend/xuwen/chat_api/llm_client.py
+++ b/backend/xuwen/chat_api/llm_client.py
@@ -214,7 +214,12 @@ class LLMClient:
             self._include_reasoning_effort
             and self.settings.llm_reasoning_effort != "null"
         ):
-            payload["reasoning_effort"] = self.settings.llm_reasoning_effort
+            if self._api_protocol == "responses":
+                payload["reasoning"] = {
+                    "effort": self.settings.llm_reasoning_effort,
+                }
+            else:
+                payload["reasoning_effort"] = self.settings.llm_reasoning_effort
         if params.temperature is not None:
             payload["temperature"] = params.temperature
         if params.top_p is not None:

--- a/backend/xuwen/chat_api/routes/chat.py
+++ b/backend/xuwen/chat_api/routes/chat.py
@@ -55,6 +55,7 @@ from xuwen.chat_api.turn_coordinator import TurnSnapshot
 from xuwen.chat_api.vision_client import VisionClient
 from xuwen.chat_api.web_fetch import render_url_context, resolve_fetch_urls
 from xuwen.chat_api.web_search import render_web_context, should_search_web
+from xuwen.companion.life import LifeSnapshot
 from xuwen.companion.response_policy import (
     ResponseDecision,
     decide_response_policy,
@@ -72,10 +73,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["chat"])
 
 _CHAT_RETRIEVAL_TIMEOUT_SECONDS = 15.0
-_CHAT_LIFE_TIMEOUT_SECONDS = 12.0
 _CHAT_RELATIONSHIP_TIMEOUT_SECONDS = 5.0
-_CHAT_RESPONSE_POLICY_TIMEOUT_SECONDS = 8.0
-_CHAT_VISION_TIMEOUT_SECONDS = 15.0
 
 
 class ChatTurnCancelRequest(BaseModel):
@@ -196,12 +194,12 @@ async def chat_completions(
             async with VisionClient(state.settings) as vc:
                 vlm_descriptions = await asyncio.wait_for(
                     vc.describe_images(images_in_last),
-                    timeout=_CHAT_VISION_TIMEOUT_SECONDS,
+                    timeout=state.settings.vision_timeout_seconds,
                 )
         except TimeoutError:
             logger.warning(
                 "VLM 描图超时 %.1fs，使用占位描述",
-                _CHAT_VISION_TIMEOUT_SECONDS,
+                state.settings.vision_timeout_seconds,
             )
             state.metrics.record("vision.describe", 0.0, error="TimeoutError")
             vlm_descriptions = ["[图片：识别超时]"] * len(images_in_last)
@@ -309,7 +307,7 @@ async def chat_completions(
     # 仍是 life 决策的核心信号，影响很小；多数轮走快路径（缓存早退）则几乎零成本。
     life_markdown = state.relationship_memory.load_markdown()
 
-    async def _life_in_parallel():
+    async def _life_in_parallel() -> LifeSnapshot:
         async with state.life_apply_lock:
             try:
                 return await asyncio.wait_for(
@@ -324,12 +322,12 @@ async def chat_completions(
                         trace_id=trace_id,
                         metrics=state.metrics,
                     ),
-                    timeout=_CHAT_LIFE_TIMEOUT_SECONDS,
+                    timeout=state.settings.life_timeout_seconds,
                 )
             except TimeoutError:
                 logger.warning(
                     "life 决策超时 %.1fs，沿用当前 snapshot",
-                    _CHAT_LIFE_TIMEOUT_SECONDS,
+                    state.settings.life_timeout_seconds,
                 )
                 state.metrics.record("life.decide", 0.0, error="TimeoutError")
                 return state.life.snapshot()
@@ -410,12 +408,12 @@ async def chat_completions(
                     trace_id=trace_id,
                     metrics=state.metrics,
                 ),
-                timeout=_CHAT_RESPONSE_POLICY_TIMEOUT_SECONDS,
+                timeout=state.settings.response_policy_timeout_seconds,
             )
         except TimeoutError:
             logger.warning(
                 "互动策略小模型超时 %.1fs，沿用规则层决策",
-                _CHAT_RESPONSE_POLICY_TIMEOUT_SECONDS,
+                state.settings.response_policy_timeout_seconds,
             )
             state.metrics.record("response.policy.refined", 0.0, error="TimeoutError")
         state.metrics.record(

--- a/backend/xuwen/chat_api/routes/companion.py
+++ b/backend/xuwen/chat_api/routes/companion.py
@@ -46,7 +46,6 @@ from xuwen.persona.prompt import build_chat_messages
 
 router = APIRouter(prefix="/v1/companion", tags=["companion"])
 logger = logging.getLogger(__name__)
-_COMPANION_RESPONSE_POLICY_TIMEOUT_SECONDS = 8.0
 
 _ASSUMED_USER_STATE_PATTERNS = (
     "你还没睡",
@@ -493,12 +492,12 @@ async def _generate_proactive_response(
                     trace_id=trace_id,
                     metrics=state.metrics,
                 ),
-                timeout=_COMPANION_RESPONSE_POLICY_TIMEOUT_SECONDS,
+                timeout=state.settings.response_policy_timeout_seconds,
             )
         except TimeoutError:
             logger.warning(
                 "主动聊天互动策略小模型超时 %.1fs，沿用规则层决策",
-                _COMPANION_RESPONSE_POLICY_TIMEOUT_SECONDS,
+                state.settings.response_policy_timeout_seconds,
             )
             state.metrics.record(
                 "companion.response.policy.refined",

--- a/backend/xuwen/chat_api/routes/responses.py
+++ b/backend/xuwen/chat_api/routes/responses.py
@@ -58,6 +58,7 @@ from xuwen.chat_api.state import AppState, get_state
 from xuwen.chat_api.vision_client import VisionClient
 from xuwen.chat_api.web_fetch import render_url_context, resolve_fetch_urls
 from xuwen.chat_api.web_search import render_web_context, should_search_web
+from xuwen.companion.life import LifeSnapshot
 from xuwen.companion.response_policy import (
     ResponseDecision,
     decide_response_policy,
@@ -73,10 +74,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["responses"])
 
 _RESPONSES_RETRIEVAL_TIMEOUT_SECONDS = 15.0
-_RESPONSES_LIFE_TIMEOUT_SECONDS = 12.0
 _RESPONSES_RELATIONSHIP_TIMEOUT_SECONDS = 5.0
-_RESPONSES_RESPONSE_POLICY_TIMEOUT_SECONDS = 8.0
-_RESPONSES_VISION_TIMEOUT_SECONDS = 15.0
 
 
 @router.post("/v1/responses", response_model=None)
@@ -122,12 +120,12 @@ async def responses(
                 async with VisionClient(state.settings) as vc:
                     vlm_descriptions = await asyncio.wait_for(
                         vc.describe_images(last_user_images),
-                        timeout=_RESPONSES_VISION_TIMEOUT_SECONDS,
+                        timeout=state.settings.vision_timeout_seconds,
                     )
             except TimeoutError:
                 logger.warning(
                     "Responses VLM 描图超时 %.1fs，使用占位描述",
-                    _RESPONSES_VISION_TIMEOUT_SECONDS,
+                    state.settings.vision_timeout_seconds,
                 )
                 state.metrics.record("responses.vision.describe", 0.0, error="TimeoutError")
                 vlm_descriptions = ["[图片：识别超时]"] * len(last_user_images)
@@ -217,7 +215,7 @@ async def responses(
     # life 进 Layer A 并发：memory_context 改用 recent，relationship_context 同步读 markdown
     life_markdown = state.relationship_memory.load_markdown()
 
-    async def _life_in_parallel():
+    async def _life_in_parallel() -> LifeSnapshot:
         async with state.life_apply_lock:
             try:
                 return await asyncio.wait_for(
@@ -232,12 +230,12 @@ async def responses(
                         trace_id=trace_id,
                         metrics=state.metrics,
                     ),
-                    timeout=_RESPONSES_LIFE_TIMEOUT_SECONDS,
+                    timeout=state.settings.life_timeout_seconds,
                 )
             except TimeoutError:
                 logger.warning(
                     "Responses life 决策超时 %.1fs，沿用当前 snapshot",
-                    _RESPONSES_LIFE_TIMEOUT_SECONDS,
+                    state.settings.life_timeout_seconds,
                 )
                 state.metrics.record("responses.life.decide", 0.0, error="TimeoutError")
                 return state.life.snapshot()
@@ -321,12 +319,12 @@ async def responses(
                     trace_id=trace_id,
                     metrics=state.metrics,
                 ),
-                timeout=_RESPONSES_RESPONSE_POLICY_TIMEOUT_SECONDS,
+                timeout=state.settings.response_policy_timeout_seconds,
             )
         except TimeoutError:
             logger.warning(
                 "Responses 互动策略小模型超时 %.1fs，沿用规则层决策",
-                _RESPONSES_RESPONSE_POLICY_TIMEOUT_SECONDS,
+                state.settings.response_policy_timeout_seconds,
             )
             state.metrics.record("response.policy.refined", 0.0, error="TimeoutError")
         state.metrics.record(

--- a/backend/xuwen/chat_api/vision_client.py
+++ b/backend/xuwen/chat_api/vision_client.py
@@ -108,6 +108,8 @@ class VisionClient:
             "max_tokens": 120,
             "temperature": 0.3,
         }
+        if self.settings.llm_reasoning_effort != "null":
+            payload["reasoning_effort"] = self.settings.llm_reasoning_effort
 
         async for attempt in AsyncRetrying(
             stop=stop_after_attempt(3),

--- a/backend/xuwen/chat_api/vision_client.py
+++ b/backend/xuwen/chat_api/vision_client.py
@@ -43,12 +43,17 @@ class VisionClient:
         settings: Settings,
         *,
         client: httpx.AsyncClient | None = None,
-        timeout_seconds: float = 60.0,
+        timeout_seconds: float | None = None,
     ) -> None:
         self.settings = settings
         self._owned_client = client is None
+        effective_timeout = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else settings.vision_timeout_seconds
+        )
         self._client = client or httpx.AsyncClient(
-            timeout=httpx.Timeout(timeout_seconds, connect=10.0),
+            timeout=httpx.Timeout(effective_timeout, connect=10.0),
         )
         # VLM 通常也走 /chat/completions 端点（多模态）
         self._url = _resolve_endpoint(str(settings.vision_api_url), "/chat/completions")

--- a/backend/xuwen/chat_api/vision_client.py
+++ b/backend/xuwen/chat_api/vision_client.py
@@ -43,17 +43,12 @@ class VisionClient:
         settings: Settings,
         *,
         client: httpx.AsyncClient | None = None,
-        timeout_seconds: float | None = None,
+        timeout_seconds: float = 60.0,
     ) -> None:
         self.settings = settings
         self._owned_client = client is None
-        effective_timeout = (
-            timeout_seconds
-            if timeout_seconds is not None
-            else settings.vision_timeout_seconds
-        )
         self._client = client or httpx.AsyncClient(
-            timeout=httpx.Timeout(effective_timeout, connect=10.0),
+            timeout=httpx.Timeout(timeout_seconds, connect=10.0),
         )
         # VLM 通常也走 /chat/completions 端点（多模态）
         self._url = _resolve_endpoint(str(settings.vision_api_url), "/chat/completions")

--- a/backend/xuwen/config.py
+++ b/backend/xuwen/config.py
@@ -21,6 +21,7 @@ RerankMode = Literal["auto", "always", "never"]
 CrossRerankProtocol = Literal["jina", "dashscope"]
 ChunkingStrategy = Literal["fixed", "adaptive"]
 ChatApiProtocol = Literal["chat_completions", "responses"]
+ReasoningEffort = Literal["none", "low", "medium", "high", "xhigh", "null"]
 
 # 关系类型到自然语言描述的默认映射（仅在用户未自定义 RELATIONSHIP_DESCRIPTION 时使用）
 _RELATIONSHIP_DEFAULTS: dict[RelationshipType, str] = {
@@ -114,6 +115,7 @@ class Settings(BaseSettings):
     chat_model: str = "gpt-4o-mini"
     chat_api_protocol: ChatApiProtocol = "chat_completions"
     chat_timeout_seconds: float = 60.0
+    llm_reasoning_effort: ReasoningEffort = "null"
 
     # ----- 联网检索（默认关闭）-----
     # 后端在调用主模型前可选查询 Tavily / SearXNG，并把摘要注入 prompt。

--- a/backend/xuwen/config.py
+++ b/backend/xuwen/config.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import math
 from functools import lru_cache
 from pathlib import Path
 from typing import Annotated, Literal
@@ -639,8 +640,8 @@ class Settings(BaseSettings):
     )
     @classmethod
     def _check_model_timeout(cls, v: float) -> float:
-        if v <= 0:
-            raise ValueError("模型 timeout 必须 > 0")
+        if not math.isfinite(v) or v <= 0:
+            raise ValueError("模型 timeout 必须为有限正数")
         return v
 
     @field_validator("web_search_max_results")

--- a/backend/xuwen/config.py
+++ b/backend/xuwen/config.py
@@ -113,6 +113,7 @@ class Settings(BaseSettings):
     openai_base_url: str = "https://api.openai.com/v1"
     chat_model: str = "gpt-4o-mini"
     chat_api_protocol: ChatApiProtocol = "chat_completions"
+    chat_timeout_seconds: float = 60.0
 
     # ----- 联网检索（默认关闭）-----
     # 后端在调用主模型前可选查询 Tavily / SearXNG，并把摘要注入 prompt。
@@ -139,6 +140,7 @@ class Settings(BaseSettings):
     life_model: str = ""
     life_temperature: float = 0.35
     life_max_tokens: int = 1500
+    life_timeout_seconds: float = 12.0
     # 最长多久让 life 模型重新判断一次当前状态。0 = 只按 next_update_at / 用户打断触发。
     life_update_interval_minutes: int = 60
     # 生活状态可建议延迟回复；这里限制实际 sleep 上限，避免请求被模型拖太久。
@@ -188,6 +190,7 @@ class Settings(BaseSettings):
     vision_api_key: SecretStr = Field(default=SecretStr(""))
     vision_model: str = "qwen-vl-plus"
     vision_describe_prompt: str = "请用一两句话客观描述这张图片的内容，不要发挥。"
+    vision_timeout_seconds: float = 15.0
     # 单张图片最大字节（base64 解码后）；超过会被拒绝
     vision_max_image_bytes: int = 8 * 1024 * 1024  # 8MB
     # 图片文件持久化目录（base64 原图按 sha256 文件名存盘）
@@ -198,6 +201,7 @@ class Settings(BaseSettings):
     embedding_api_key: SecretStr = Field(default=SecretStr(""))
     embedding_model: str = "xop3qwen8bembedding"
     embedding_dim: int = 4096
+    embedding_timeout_seconds: float = 60.0
     # 请求格式：array = OpenAI 标准（input 是 string[]，一次多条）
     #         single = 单条模式（input 是 string，一次只能一条），兼容 Gitee AI 等
     embedding_input_mode: Literal["array", "single"] = "array"
@@ -271,6 +275,7 @@ class Settings(BaseSettings):
     adaptive_chunk_model: str = ""
     adaptive_chunk_temperature: float = 0.0
     adaptive_chunk_max_tokens: int = 900
+    adaptive_chunk_timeout_seconds: float = 60.0
     adaptive_chunk_max_messages_per_call: int = 80
     adaptive_chunk_target_chars: int = 700
     adaptive_chunk_max_chars: int = 1400
@@ -317,6 +322,7 @@ class Settings(BaseSettings):
     query_rewrite_temperature: float = 0.0
     query_rewrite_max_tokens: int = 240
     query_rewrite_max_variants: int = 3
+    query_rewrite_timeout_seconds: float = 30.0
     # 可选：RRF 召回后调用小模型对候选记忆语义重排。
     rerank_enabled: bool = False
     rerank_mode: RerankMode = "auto"
@@ -360,6 +366,7 @@ class Settings(BaseSettings):
     response_policy_model: str = ""
     response_policy_temperature: float = 0.2
     response_policy_max_tokens: int = 260
+    response_policy_timeout_seconds: float = 8.0
 
     # ----- 定时任务提取小模型（默认关闭）-----
     # 主聊天模型仅需在回复里输出 <schedule-hint>明天早上7点叫我起床</schedule-hint>，
@@ -372,6 +379,7 @@ class Settings(BaseSettings):
     schedule_model: str = ""
     schedule_temperature: float = 0.1
     schedule_max_tokens: int = 400
+    schedule_timeout_seconds: float = 60.0
     # 单轮最多解析的 hint 数量，防止主模型刷屏导致小模型成本失控
     schedule_max_hints_per_turn: int = 5
     # 整批解析的总超时（秒），到点未完成则 fail-open 返回空列表。
@@ -461,6 +469,7 @@ class Settings(BaseSettings):
     label_api_url: str = "https://open.bigmodel.cn/api/paas/v4"
     label_api_key: SecretStr = Field(default=SecretStr(""))
     label_model: str = "glm-4-flash"
+    label_timeout_seconds: float = 30.0
     # 单次 LLM 调用最多塞几条消息（受小模型上下文窗口与可靠性影响）
     label_batch_size: int = 8
     # 打标 API 最大并发批次数。1 = 上一批处理完再下一批；GLM-4-Flash 并发 20 可设 15。
@@ -613,18 +622,23 @@ class Settings(BaseSettings):
             raise ValueError("调优整数参数必须 >= 0")
         return v
 
-    @field_validator("rerank_timeout_seconds")
+    @field_validator(
+        "chat_timeout_seconds",
+        "life_timeout_seconds",
+        "vision_timeout_seconds",
+        "embedding_timeout_seconds",
+        "adaptive_chunk_timeout_seconds",
+        "query_rewrite_timeout_seconds",
+        "rerank_timeout_seconds",
+        "cross_rerank_timeout_seconds",
+        "response_policy_timeout_seconds",
+        "schedule_timeout_seconds",
+        "label_timeout_seconds",
+    )
     @classmethod
-    def _check_rerank_timeout(cls, v: float) -> float:
+    def _check_model_timeout(cls, v: float) -> float:
         if v <= 0:
-            raise ValueError("rerank_timeout_seconds 必须 > 0")
-        return v
-
-    @field_validator("cross_rerank_timeout_seconds")
-    @classmethod
-    def _check_cross_rerank_timeout(cls, v: float) -> float:
-        if v <= 0:
-            raise ValueError("cross_rerank_timeout_seconds 必须 > 0")
+            raise ValueError("模型 timeout 必须 > 0")
         return v
 
     @field_validator("web_search_max_results")

--- a/backend/xuwen/ingestion/embedder.py
+++ b/backend/xuwen/ingestion/embedder.py
@@ -104,7 +104,7 @@ class EmbeddingClient:
         self.settings = settings
         self._owned_client = client is None
         self._client = client or httpx.AsyncClient(
-            timeout=httpx.Timeout(60.0, connect=10.0),
+            timeout=httpx.Timeout(settings.embedding_timeout_seconds, connect=10.0),
         )
         self._url = _resolve_endpoint(str(settings.embedding_api_url), "/embeddings")
         self._headers = {

--- a/backend/xuwen/ingestion/importer.py
+++ b/backend/xuwen/ingestion/importer.py
@@ -132,6 +132,7 @@ async def import_history(
                     settings,
                     api_url=settings.resolved_adaptive_chunk_api_url,
                     api_key=settings.resolved_adaptive_chunk_api_key.get_secret_value(),
+                    timeout_seconds=settings.adaptive_chunk_timeout_seconds,
                 )
             else:
                 _stage(f"正在用启发式 adaptive 切分窗口（{len(sessions)} 个会话）")

--- a/backend/xuwen/ingestion/importer.py
+++ b/backend/xuwen/ingestion/importer.py
@@ -133,6 +133,7 @@ async def import_history(
                     api_url=settings.resolved_adaptive_chunk_api_url,
                     api_key=settings.resolved_adaptive_chunk_api_key.get_secret_value(),
                     timeout_seconds=settings.adaptive_chunk_timeout_seconds,
+                    include_reasoning_effort=True,
                 )
             else:
                 _stage(f"正在用启发式 adaptive 切分窗口（{len(sessions)} 个会话）")

--- a/backend/xuwen/persona/labeler.py
+++ b/backend/xuwen/persona/labeler.py
@@ -151,6 +151,8 @@ class Labeler:
             "max_tokens": 600,
             "response_format": {"type": "json_object"},
         }
+        if self.settings.llm_reasoning_effort != "null":
+            payload["reasoning_effort"] = self.settings.llm_reasoning_effort
 
         async for attempt in AsyncRetrying(
             stop=stop_after_attempt(3),

--- a/backend/xuwen/persona/labeler.py
+++ b/backend/xuwen/persona/labeler.py
@@ -69,12 +69,17 @@ class Labeler:
         settings: Settings,
         *,
         client: httpx.AsyncClient | None = None,
-        timeout_seconds: float = 30.0,
+        timeout_seconds: float | None = None,
     ) -> None:
         self.settings = settings
         self._owned_client = client is None
+        effective_timeout = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else settings.label_timeout_seconds
+        )
         self._client = client or httpx.AsyncClient(
-            timeout=httpx.Timeout(timeout_seconds, connect=10.0),
+            timeout=httpx.Timeout(effective_timeout, connect=10.0),
         )
         self._url = _resolve_endpoint(str(settings.label_api_url), "/chat/completions")
         self._headers = {

--- a/docs/wiki/后端环境变量.md
+++ b/docs/wiki/后端环境变量.md
@@ -149,7 +149,7 @@ Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓
 | `VISION_API_KEY` | 留空 | 独立 VLM 密钥。 |
 | `VISION_MODEL` | `qwen-vl-plus` | 独立 VLM 模型名。 |
 | `VISION_DESCRIBE_PROMPT` | `请用一两句话客观描述这张图片的内容，不要发挥。` | 图片转文本的提示词。 |
-| `VISION_TIMEOUT_SECONDS` | `15` | VLM 请求超时秒数，必须大于 `0`。 |
+| `VISION_TIMEOUT_SECONDS` | `15` | 在线 chat/responses 路由等待 VLM 描图的总预算秒数，必须大于 `0`；不改变 `VisionClient` 默认 60 秒 HTTP 超时。 |
 | `VISION_MAX_IMAGE_BYTES` | `8388608` | 单张图片最大字节，默认 8 MiB。 |
 | `IMAGE_DATA_DIR` | `.data/images` | 按 SHA-256 保存历史原图的目录。 |
 

--- a/docs/wiki/后端环境变量.md
+++ b/docs/wiki/后端环境变量.md
@@ -1,7 +1,7 @@
 # 后端配置与环境变量
 
 Afterglow 后端通过 `pydantic-settings` 读取环境变量和 `backend/.env`。本页覆盖当前 `Settings`
-支持的全部 207 个字段；可复制的模板见
+支持的全部 208 个字段；可复制的模板见
 [`backend/.env.example`](https://github.com/kldhsh123/Afterglow/blob/main/backend/.env.example)。
 
 > [!IMPORTANT]
@@ -61,6 +61,7 @@ Afterglow 后端通过 `pydantic-settings` 读取环境变量和 `backend/.env`�
 | `CHAT_MODEL` | `gpt-4o` | 生成最终回复的模型；无 `.env` 时代码回退为 `gpt-4o-mini`。 |
 | `CHAT_API_PROTOCOL` | `chat_completions` | 主模型上游协议：`chat_completions` 或 `responses`；只影响主模型。 |
 | `CHAT_TIMEOUT_SECONDS` | `60` | 主聊天模型请求超时秒数，必须大于 `0`。 |
+| `LLM_REASONING_EFFORT` | `null` | OpenAI 兼容 LLM reasoning effort；`none`, `low`, `medium`, `high`, `xhigh` 会传给上游，`null` 不传该字段。适用于主聊天、Life、互动决策、Schedule、Query Rewrite、Adaptive Chunk、Label、VLM；不作用于 Embedding、搜索、Rerank。 |
 
 Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓存而持久化响应。Prompt 缓存由支持它的上游自动处理，是否命中仍取决于服务商能力、输入长度和前缀是否完全一致；切换协议不代表必然节省 token。调试端点的 `model_chain[].response.usage.cached_tokens` 可查看上游报告的缓存命中 token 数。生活状态、互动决策、Query Rewrite 和 LLM Rerank 等辅助模型仍使用 Chat Completions 协议。
 

--- a/docs/wiki/后端环境变量.md
+++ b/docs/wiki/后端环境变量.md
@@ -1,7 +1,7 @@
 # 后端配置与环境变量
 
 Afterglow 后端通过 `pydantic-settings` 读取环境变量和 `backend/.env`。本页覆盖当前 `Settings`
-支持的全部 197 个字段；可复制的模板见
+支持的全部 207 个字段；可复制的模板见
 [`backend/.env.example`](https://github.com/kldhsh123/Afterglow/blob/main/backend/.env.example)。
 
 > [!IMPORTANT]
@@ -60,6 +60,7 @@ Afterglow 后端通过 `pydantic-settings` 读取环境变量和 `backend/.env`�
 | `OPENAI_BASE_URL` | `https://api.openai.com/v1` | OpenAI 兼容基础 URL，不要重复填 `/chat/completions` 或 `/responses`。 |
 | `CHAT_MODEL` | `gpt-4o` | 生成最终回复的模型；无 `.env` 时代码回退为 `gpt-4o-mini`。 |
 | `CHAT_API_PROTOCOL` | `chat_completions` | 主模型上游协议：`chat_completions` 或 `responses`；只影响主模型。 |
+| `CHAT_TIMEOUT_SECONDS` | `60` | 主聊天模型请求超时秒数，必须大于 `0`。 |
 
 Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓存而持久化响应。Prompt 缓存由支持它的上游自动处理，是否命中仍取决于服务商能力、输入长度和前缀是否完全一致；切换协议不代表必然节省 token。调试端点的 `model_chain[].response.usage.cached_tokens` 可查看上游报告的缓存命中 token 数。生活状态、互动决策、Query Rewrite 和 LLM Rerank 等辅助模型仍使用 Chat Completions 协议。
 
@@ -72,6 +73,7 @@ Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓
 | `LIFE_MODEL` | 留空 | 维护 `life_state.json` 的模型名，空时复用 `CHAT_MODEL`。 |
 | `LIFE_TEMPERATURE` | `0.35` | 状态 JSON 生成温度，取值 `0..2`。 |
 | `LIFE_MAX_TOKENS` | `1500` | 状态 JSON 最大输出 token；thinking 模型需预留推理 token。 |
+| `LIFE_TIMEOUT_SECONDS` | `12` | 生活状态模型请求超时秒数，必须大于 `0`。 |
 | `LIFE_UPDATE_INTERVAL_MINUTES` | `60` | 最长重新判断状态间隔；`0` 表示只按事件和 `next_update_at` 触发。 |
 | `LIFE_MAX_REPLY_DELAY_SECONDS` | `45` | 生活状态建议的回复延迟上限。 |
 | `LIFE_SLEEPING_MIN_REPLY_DELAY_SECONDS` | `8` | `sleeping` 状态的最小延迟兜底；`0` 关闭。 |
@@ -87,6 +89,7 @@ Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓
 | `RESPONSE_POLICY_MODEL` | 留空 | 决策模型名，空时复用 Life / 主模型。 |
 | `RESPONSE_POLICY_TEMPERATURE` | `0.2` | 决策输出温度。 |
 | `RESPONSE_POLICY_MAX_TOKENS` | `260` | 决策 JSON 最大输出 token。 |
+| `RESPONSE_POLICY_TIMEOUT_SECONDS` | `8` | 决策模型请求超时秒数，必须大于 `0`。 |
 
 ## 输出、沉默与 Responses API
 
@@ -125,6 +128,7 @@ Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓
 | `EMBEDDING_API_KEY` | 留空 | Embedding 服务密钥。 |
 | `EMBEDDING_MODEL` | `xop3qwen8bembedding` | 向量模型名。 |
 | `EMBEDDING_DIM` | `4096` | 模型输出和 LanceDB schema 维度，必须一致且大于 `0`。 |
+| `EMBEDDING_TIMEOUT_SECONDS` | `60` | Embedding 请求超时秒数，必须大于 `0`。 |
 | `EMBEDDING_INPUT_MODE` | `array` | `array` 批量标准协议或 `single` 单条协议。 |
 | `EMBEDDING_BATCH_SIZE` | `25` | 每次请求最多文本数；`single` 模式强制为 `1`。 |
 | `EMBEDDING_MAX_CONCURRENCY` | `20` | 同时在途的 HTTP 请求上限，必须大于 `0`。 |
@@ -144,6 +148,7 @@ Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓
 | `VISION_API_KEY` | 留空 | 独立 VLM 密钥。 |
 | `VISION_MODEL` | `qwen-vl-plus` | 独立 VLM 模型名。 |
 | `VISION_DESCRIBE_PROMPT` | `请用一两句话客观描述这张图片的内容，不要发挥。` | 图片转文本的提示词。 |
+| `VISION_TIMEOUT_SECONDS` | `15` | VLM 请求超时秒数，必须大于 `0`。 |
 | `VISION_MAX_IMAGE_BYTES` | `8388608` | 单张图片最大字节，默认 8 MiB。 |
 | `IMAGE_DATA_DIR` | `.data/images` | 按 SHA-256 保存历史原图的目录。 |
 
@@ -209,6 +214,7 @@ Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓
 | `ADAPTIVE_CHUNK_MODEL` | 留空 | 切分模型名。 |
 | `ADAPTIVE_CHUNK_TEMPERATURE` | `0` | 分界输出温度，取值 `0..2`。 |
 | `ADAPTIVE_CHUNK_MAX_TOKENS` | `900` | 单次分界 JSON 最大输出 token。 |
+| `ADAPTIVE_CHUNK_TIMEOUT_SECONDS` | `60` | adaptive 切分模型请求超时秒数，必须大于 `0`。 |
 | `ADAPTIVE_CHUNK_MAX_MESSAGES_PER_CALL` | `80` | 单次交给分界模型的最大消息数。 |
 | `ADAPTIVE_CHUNK_TARGET_CHARS` | `700` | 目标 chunk 字符数。 |
 | `ADAPTIVE_CHUNK_MAX_CHARS` | `1400` | chunk 字符硬上限，必须不小于目标值。 |
@@ -249,6 +255,7 @@ Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓
 | `QUERY_REWRITE_TEMPERATURE` | `0` | 改写温度，取值 `0..2`。 |
 | `QUERY_REWRITE_MAX_TOKENS` | `240` | 改写结果最大 token。 |
 | `QUERY_REWRITE_MAX_VARIANTS` | `3` | 包含原查询在内的最大查询变体数。 |
+| `QUERY_REWRITE_TIMEOUT_SECONDS` | `30` | 改写模型请求超时秒数，必须大于 `0`。 |
 
 ## LLM Rerank（实验性）
 
@@ -290,6 +297,7 @@ Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓
 | `SCHEDULE_MODEL` | 留空 | 提取模型名。 |
 | `SCHEDULE_TEMPERATURE` | `0.1` | 时间解析 JSON 温度。 |
 | `SCHEDULE_MAX_TOKENS` | `400` | 提取 JSON 最大 token。 |
+| `SCHEDULE_TIMEOUT_SECONDS` | `60` | 定时任务提取模型请求超时秒数，必须大于 `0`。 |
 | `SCHEDULE_MAX_HINTS_PER_TURN` | `5` | 单轮最多解析的 hint 数。 |
 | `SCHEDULE_EXTRACT_TIMEOUT_SECONDS` | `10` | 整批解析超时；失败返回空且不阻断主回复。 |
 
@@ -328,6 +336,7 @@ Responses 模式会向上游发送 `store=false`，不会为了使用 Prompt 缓
 | `LABEL_API_URL` | `https://open.bigmodel.cn/api/paas/v4` | OpenAI 兼容打标模型 URL。 |
 | `LABEL_API_KEY` | 留空 | 打标模型密钥。 |
 | `LABEL_MODEL` | `glm-4-flash` | 打标模型名。 |
+| `LABEL_TIMEOUT_SECONDS` | `30` | 打标模型请求超时秒数，必须大于 `0`。 |
 | `LABEL_BATCH_SIZE` | `8` | 单次打标请求的消息数。 |
 | `LABEL_MAX_CONCURRENCY` | `19` | 同时在途的打标批次；无 `.env` 时代码回退为 `1`。 |
 | `LABEL_REQUEST_INTERVAL_SECONDS` | `0` | 相邻请求启动间隔；`0` 不额外等待。 |


### PR DESCRIPTION
## 做了什么

- 为后端各类模型请求暴露 timeout 环境变量，并同步 `.env.example` 与后端环境变量文档。
- 保留已有 timeout 行为的默认值；仅把原先硬编码/客户端默认值配置化。
- 新增 `LLM_REASONING_EFFORT`：
  - 支持 `none` / `low` / `medium` / `high` / `xhigh` / `null`
  - 默认 `null`
  - `null` 时不向上游发送 `reasoning_effort`，兼容不支持推理参数的模型
  - 非 `null` 时向 OpenAI 兼容 LLM 请求发送该字段

## 作用范围

`LLM_REASONING_EFFORT` 作用于：

- 主聊天 LLM
- Life 状态模型
- 互动决策模型
- Schedule 提取模型
- Query Rewrite 模型
- Adaptive Chunk 模型
- Label 打标模型
- VLM 图片描述模型

不作用于：

- Embedding
- 搜索
- Rerank / Cross Rerank

## 注意

- 本次只修改后端与后端文档。
- 未修改前端或配置 UI；前端配置保持默认，用户如需调整可手动编辑后端 `.env`。

## 自检

- [x] `uv run ruff check xuwen`
- [x] `git diff --check`
- [x] `uv run mypy xuwen`

`mypy` 当前仍有既有错误，主要集中在 `ingestion/chunker.py`、`ingestion/cli.py`、`web_ui/*` 等文件；本次触碰文件中由改动引入的类型问题已处理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增多项模型调用超时配置（涵盖主聊天、视觉理解、Embedding、查询改写、互动决策、自适应切分、定时任务、语义标签等）。
  - 新增推理强度配置（可选择级别或关闭），并应用到相关模型的请求策略中。
- **改进**
  - 统一校验各类超时配置，减少无效配置带来的异常。
  - 保持原有超时降级与告警提示逻辑，提升稳定性。
- **文档**
  - 更新后端环境变量文档，补充新增配置项与适用说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->